### PR TITLE
Move exceptions to BatchResult

### DIFF
--- a/spec/Exception/BatchExceptionSpec.php
+++ b/spec/Exception/BatchExceptionSpec.php
@@ -9,6 +9,11 @@ use PhpSpec\ObjectBehavior;
 
 class BatchExceptionSpec extends ObjectBehavior
 {
+    function let(BatchResult $batchResult)
+    {
+        $this->beConstructedWith($batchResult);
+    }
+
     function it_is_initializable()
     {
         $this->shouldHaveType('Http\Client\Exception\BatchException');
@@ -24,50 +29,8 @@ class BatchExceptionSpec extends ObjectBehavior
         $this->shouldImplement('Http\Client\Exception');
     }
 
-    function it_throws_an_exception_if_the_result_is_not_available()
+    function it_has_a_batch_result()
     {
-        $this->shouldThrow('RuntimeException')->duringGetResult();
-    }
-
-    function it_throws_an_exception_if_the_result_is_already_set(BatchResult $batchResult)
-    {
-        $this->setResult($batchResult);
-
         $this->getResult()->shouldHaveType('Http\Client\BatchResult');
-        $this->shouldThrow('RuntimeException')->duringSetResult($batchResult);
-    }
-
-    function it_has_an_exception_for_a_request(RequestInterface $request, Exception $exception)
-    {
-        $this->shouldThrow('UnexpectedValueException')->duringGetExceptionFor($request);
-        $this->hasExceptionFor($request)->shouldReturn(false);
-
-        $this->addException($request, $exception);
-
-        $this->getExceptionFor($request)->shouldReturn($exception);
-        $this->hasExceptionFor($request)->shouldReturn(true);
-    }
-
-    function it_has_exceptions(RequestInterface $request, Exception $exception)
-    {
-        $this->getExceptions()->shouldReturn([]);
-
-        $this->addException($request, $exception);
-
-        $this->getExceptions()->shouldReturn([$exception]);
-    }
-
-    function it_checks_if_a_request_failed(RequestInterface $request, Exception $exception, BatchResult $batchResult)
-    {
-        $batchResult->hasResponseFor($request)->willReturn(false);
-        $this->setResult($batchResult);
-
-        $this->isSuccessful($request)->shouldReturn(false);
-        $this->isFailed($request)->shouldReturn(false);
-
-        $this->addException($request, $exception);
-
-        $this->isSuccessful($request)->shouldReturn(false);
-        $this->isFailed($request)->shouldReturn(true);
     }
 }

--- a/src/BatchResult.php
+++ b/src/BatchResult.php
@@ -7,7 +7,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
- * Successful responses returned from parallel request execution
+ * Responses and exceptions returned from parallel request execution
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
  */
@@ -54,8 +54,61 @@ interface BatchResult
      * @param ResponseInterface $response
      *
      * @return BatchResult
-     *
-     * @internal
      */
     public function addResponse(RequestInterface $request, ResponseInterface $response);
+
+    /**
+     * Checks if a request is successful
+     *
+     * @param RequestInterface $request
+     *
+     * @return boolean
+     */
+    public function isSuccessful(RequestInterface $request);
+
+    /**
+     * Checks if a request is failed
+     *
+     * @param RequestInterface $request
+     *
+     * @return boolean
+     */
+    public function isFailed(RequestInterface $request);
+
+    /**
+     * Returns all exceptions
+     *
+     * @return Exception[]
+     */
+    public function getExceptions();
+
+    /**
+     * Returns an exception for a request
+     *
+     * @param RequestInterface $request
+     *
+     * @return Exception
+     *
+     * @throws \UnexpectedValueException If request is not found
+     */
+    public function getExceptionFor(RequestInterface $request);
+
+    /**
+     * Checks if there is an exception for a request
+     *
+     * @param RequestInterface $request
+     *
+     * @return boolean
+     */
+    public function hasExceptionFor(RequestInterface $request);
+
+    /**
+     * Adds an exception
+     *
+     * @param RequestInterface  $request
+     * @param Exception         $exception
+     *
+     * @return BatchResult
+     */
+    public function addException(RequestInterface $request, Exception $exception);
 }

--- a/src/Exception/BatchException.php
+++ b/src/Exception/BatchException.php
@@ -21,129 +21,20 @@ final class BatchException extends \RuntimeException implements Exception
     private $result;
 
     /**
-     * @var \SplObjectStorage
-     */
-    private $exceptions;
-
-    public function __construct()
-    {
-        $this->exceptions = new \SplObjectStorage();
-    }
-
-    /**
-     * Returns the BatchResult that contains those responses that where successful.
-     *
-     * Note that the BatchResult may contains 0 responses if all requests failed.
-     *
-     * @return BatchResult
-     *
-     * @throws \RuntimeException If the BatchResult is not available
-     */
-    public function getResult()
-    {
-        if (!isset($this->result)) {
-            throw new \RuntimeException('BatchResult is not available');
-        }
-
-        return $this->result;
-    }
-
-    /**
-     * Sets the successful response list
-     *
      * @param BatchResult $result
-     *
-     * @throws \RuntimeException If the BatchResult is already set
-     *
-     * @internal
      */
-    public function setResult(BatchResult $result)
+    public function __construct(BatchResult $result)
     {
-        if (isset($this->result)) {
-            throw new \RuntimeException('BatchResult is already set');
-        }
-
         $this->result = $result;
     }
 
     /**
-     * Checks if a request is successful
+     * Returns the BatchResult that contains all responses and exceptions
      *
-     * @param RequestInterface $request
-     *
-     * @return boolean
+     * @return BatchResult
      */
-    public function isSuccessful(RequestInterface $request)
+    public function getResult()
     {
-        return $this->getResult()->hasResponseFor($request);
-    }
-
-    /**
-     * Checks if a request is failed
-     *
-     * @param RequestInterface $request
-     *
-     * @return boolean
-     */
-    public function isFailed(RequestInterface $request)
-    {
-        return $this->exceptions->contains($request);
-    }
-
-    /**
-     * Returns all exceptions
-     *
-     * @return Exception[]
-     */
-    public function getExceptions()
-    {
-        $exceptions = [];
-
-        foreach ($this->exceptions as $request) {
-            $exceptions[] = $this->exceptions[$request];
-        }
-
-        return $exceptions;
-    }
-
-    /**
-     * Returns an exception for a request
-     *
-     * @param RequestInterface $request
-     *
-     * @return Exception
-     *
-     * @throws \UnexpectedValueException If request is not found
-     */
-    public function getExceptionFor(RequestInterface $request)
-    {
-        try {
-            return $this->exceptions[$request];
-        } catch (\UnexpectedValueException $e) {
-            throw new \UnexpectedValueException('Request not found', $e->getCode(), $e);
-        }
-    }
-
-    /**
-     * Checks if there is an exception for a request
-     *
-     * @param RequestInterface $request
-     *
-     * @return boolean
-     */
-    public function hasExceptionFor(RequestInterface $request)
-    {
-        return $this->exceptions->contains($request);
-    }
-
-    /**
-     * Adds an exception
-     *
-     * @param RequestInterface  $request
-     * @param Exception         $exception
-     */
-    public function addException(RequestInterface $request, Exception $exception)
-    {
-        $this->exceptions->attach($request, $exception);
+        return $this->result;
     }
 }


### PR DESCRIPTION
I am coming up with this solution again. If we decide to merge #60, we should consider merging this one as well.

Based on how the [BatchRequest trait](https://github.com/php-http/adapter/blob/master/src/Util/BatchRequest.php) is created, it turns out that the current BatchResult-BatchException solution is not really efficient.

Moving everything to the BatchResponse (again) makes it easier to collect everything in one place and think later about exceptions.

This solution also allows to wrap existing batch objects in cases a client supports parallel execution (like in case of guzzle6)

I also think that the API is easier to read this way. We can also forget about the `@internal` docblock we added because Exceptions cannot be cloned.

To sum up, there are plenty of advantages to move exceptions to the BatchResult object.

What do you think?
