### PR TITLE
cleanup phpdoc and BatchResult interface

### DIFF
--- a/spec/Exception/RequestExceptionSpec.php
+++ b/spec/Exception/RequestExceptionSpec.php
@@ -27,18 +27,4 @@ class RequestExceptionSpec extends ObjectBehavior
     {
         $this->getRequest()->shouldReturn($request);
     }
-
-    function it_wraps_an_exception(RequestInterface $request)
-    {
-        $e = new \Exception('message');
-
-        $requestException = $this->wrapException($request, $e);
-
-        $requestException->getMessage()->shouldReturn('message');
-    }
-
-    function it_does_not_wrap_if_request_exception(RequestInterface $request, RequestException $requestException)
-    {
-        $this->wrapException($request, $requestException)->shouldReturn($requestException);
-    }
 }

--- a/spec/Exception/TransferExceptionSpec.php
+++ b/spec/Exception/TransferExceptionSpec.php
@@ -2,14 +2,14 @@
 
 namespace spec\Http\Client\Exception;
 
+use Http\Client\Exception\TransferException;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class TransferExceptionSpec extends ObjectBehavior
 {
-    function it_is_initializable()
+    function let()
     {
-        $this->shouldHaveType('Http\Client\Exception\TransferException');
+        $this->beAnInstanceOf('spec\Http\Client\Exception\TransferExceptionStub');
     }
 
     function it_is_a_runtime_exception()
@@ -21,4 +21,8 @@ class TransferExceptionSpec extends ObjectBehavior
     {
         $this->shouldImplement('Http\Client\Exception');
     }
+}
+
+class TransferExceptionStub extends TransferException
+{
 }

--- a/src/BatchResult.php
+++ b/src/BatchResult.php
@@ -14,11 +14,27 @@ use Psr\Http\Message\ResponseInterface;
 interface BatchResult
 {
     /**
+     * Checks if there are any successful responses at all.
+     *
+     * @return boolean
+     */
+    public function hasResponses();
+
+    /**
      * Returns all successful responses.
      *
      * @return ResponseInterface[]
      */
     public function getResponses();
+
+    /**
+     * Checks if there is a successful response for a request.
+     *
+     * @param RequestInterface $request
+     *
+     * @return boolean
+     */
+    public function isSuccessful(RequestInterface $request);
 
     /**
      * Returns the response for a successful request.
@@ -32,22 +48,6 @@ interface BatchResult
     public function getResponseFor(RequestInterface $request);
 
     /**
-     * Checks if there are any successful responses at all
-     *
-     * @return boolean
-     */
-    public function hasResponses();
-
-    /**
-     * Checks if there is a successful response for a request.
-     *
-     * @param RequestInterface $request
-     *
-     * @return ResponseInterface
-     */
-    public function hasResponseFor(RequestInterface $request);
-
-    /**
      * Adds a response in an immutable way.
      *
      * @param RequestInterface  $request
@@ -58,22 +58,11 @@ interface BatchResult
     public function addResponse(RequestInterface $request, ResponseInterface $response);
 
     /**
-     * Checks if a request was successful.
-     *
-     * @param RequestInterface $request
+     * Checks if there are any unsuccessful requests at all.
      *
      * @return boolean
      */
-    public function isSuccessful(RequestInterface $request);
-
-    /**
-     * Checks if a request has failed.
-     *
-     * @param RequestInterface $request
-     *
-     * @return boolean
-     */
-    public function isFailed(RequestInterface $request);
+    public function hasExceptions();
 
     /**
      * Returns all exceptions for the unsuccessful requests.
@@ -81,6 +70,15 @@ interface BatchResult
      * @return Exception[]
      */
     public function getExceptions();
+
+    /**
+     * Checks if there is an exception for a request, meaning the request failed.
+     *
+     * @param RequestInterface $request
+     *
+     * @return boolean
+     */
+    public function isFailed(RequestInterface $request);
 
     /**
      * Returns the exception for a failed request.
@@ -92,15 +90,6 @@ interface BatchResult
      * @throws \UnexpectedValueException If request was not part of the batch or was successful.
      */
     public function getExceptionFor(RequestInterface $request);
-
-    /**
-     * Checks if there is an exception for a request.
-     *
-     * @param RequestInterface $request
-     *
-     * @return boolean
-     */
-    public function hasExceptionFor(RequestInterface $request);
 
     /**
      * Adds an exception in an immutable way.

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -3,7 +3,7 @@
 namespace Http\Client;
 
 /**
- * Every HTTP Client related Exception should implement this interface
+ * Every HTTP Client related Exception must implement this interface
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
  */

--- a/src/Exception/BatchException.php
+++ b/src/Exception/BatchException.php
@@ -6,13 +6,13 @@ use Http\Client\BatchResult;
 use Http\Client\Exception;
 
 /**
- * This exception is thrown when a batch of requests led to at least one failure.
+ * This exception is thrown when HttpClient::sendRequests led to at least one failure.
  *
- * It holds the response/exception pairs and gives access to a BatchResult with the successful responses.
+ * It gives access to a BatchResult with the request-exception and request-response pairs.
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
  */
-final class BatchException extends \RuntimeException implements Exception
+final class BatchException extends TransferException implements Exception
 {
     /**
      * @var BatchResult

--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -8,7 +8,7 @@ use Psr\Http\Message\ResponseInterface;
 /**
  * Thrown when a response was received but has an error status code.
  *
- * This exception always provides the request and response objects.
+ * In addition to the request, this exception always provides access to the response object.
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
  */
@@ -31,11 +31,10 @@ class HttpException extends RequestException
         ResponseInterface $response,
         \Exception $previous = null
     ) {
+        parent::__construct($message, $request, $previous);
+
         $this->response = $response;
         $this->code = $response->getStatusCode();
-
-
-        parent::__construct($message, $request, $previous);
     }
 
     /**

--- a/src/Exception/NetworkException.php
+++ b/src/Exception/NetworkException.php
@@ -3,7 +3,9 @@
 namespace Http\Client\Exception;
 
 /**
- * Thrown when the request cannot be completed caused by network issues
+ * Thrown when the request cannot be completed because of network issues.
+ *
+ * There is no response object as this exception is thrown when no response has been received.
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
  */

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -5,7 +5,10 @@ namespace Http\Client\Exception;
 use Psr\Http\Message\RequestInterface;
 
 /**
- * Base exception for when a request failed.
+ * Exception for when a request failed, providing access to the failed request.
+ *
+ * This could be due to an invalid request, or one of the extending exceptions
+ * for network errors or HTTP error responses.
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
  */
@@ -36,20 +39,5 @@ class RequestException extends TransferException
     public function getRequest()
     {
         return $this->request;
-    }
-
-    /**
-     * @param RequestInterface $request
-     * @param \Exception       $e
-     *
-     * @return RequestException
-     */
-    public static function wrapException(RequestInterface $request, \Exception $e)
-    {
-        if (!$e instanceof RequestException) {
-            $e = new RequestException($e->getMessage(), $request, $e);
-        }
-
-        return $e;
     }
 }

--- a/src/Exception/TransferException.php
+++ b/src/Exception/TransferException.php
@@ -9,6 +9,6 @@ use Http\Client\Exception;
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
  */
-class TransferException extends \RuntimeException implements Exception
+abstract class TransferException extends \RuntimeException implements Exception
 {
 }

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -16,7 +16,7 @@ use Psr\Http\Message\ResponseInterface;
 interface HttpClient
 {
     /**
-     * Sends a PSR request
+     * Sends a PSR-7 request.
      *
      * @param RequestInterface $request
      *
@@ -27,17 +27,20 @@ interface HttpClient
     public function sendRequest(RequestInterface $request);
 
     /**
-     * Sends PSR requests
+     * Sends several PSR-7 requests.
      *
-     * If one or more requests led to an exception, the BatchException is thrown.
-     * The BatchException also gives access to the BatchResult for the successful responses.
+     * If the client is able to, these requests should be sent in parallel. Otherwise they will be sent sequentially.
+     * Either way, the caller may not rely on them being executed in any particular order.
+     *
+     * If one or more requests led to an exception, the BatchException is thrown. The BatchException gives access to the
+     * BatchResult that contains responses for successful calls and exceptions for unsuccessful calls.
      *
      * @param RequestInterface[] $requests
      *
      * @return BatchResult If all requests where successful.
      *
-     * @throws Exception
-     * @throws BatchException
+     * @throws Exception      On general setup problems.
+     * @throws BatchException If one or more requests led to exceptions.
      */
     public function sendRequests(array $requests);
 }


### PR DESCRIPTION
mainly adjusting the exceptions, but i also went over the BatchResult interface. we had duplicated methods and i reordered them to be consistent.

isSuccessful and hasResponseFor are the same
as are isFailed and hasExceptionFor

i went with isSuccessful and isFailed, but maybe hasExceptionFor / hasResponseFor would be more straightforward. wdyt?
