### PR TITLE
Async Http Client

### DIFF
--- a/src/HttpAsyncClient.php
+++ b/src/HttpAsyncClient.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Http\Client;
+
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Sends a PSR-7 Request in an asynchronous way by returning a Promise.
+ *
+ * @author Joel Wurtz <joel.wurtz@gmail.com>
+ */
+interface HttpAsyncClient
+{
+    /**
+     * Sends a PSR-7 request in an asynchronous way.
+     *
+     * @param RequestInterface $request
+     *
+     * @return Promise
+     *
+     * @throws Exception
+     */
+    public function sendAsyncRequest(RequestInterface $request);
+}

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -2,7 +2,6 @@
 
 namespace Http\Client;
 
-use Http\Client\Exception\BatchException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -44,7 +44,7 @@ interface Promise
      *
      * @param callable $onFulfilled Called when a response will be available.
      *
-     * It will receive a Psr\Http\Message\RequestInterface object as the first argument
+     * It will receive a Psr\Http\Message\ResponseInterface object as the first argument
      * If the callback is null it must not be called.
      * It must be called after promise is fulfilled, with promise’s value (ResponseInterface) as its first argument.
      * It must not be called before promise is fulfilled.

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -8,6 +8,10 @@ use Psr\Http\Message\ResponseInterface;
  * Promise represents a response that may not be available yet, but will be resolved at some point in future.
  * It acts like a proxy to the actual response.
  *
+ * This interface is an extension of the promises/a+ specification https://promisesaplus.com/
+ * Value is replaced by an object where its class implement a Psr\Http\Message\RequestInterface.
+ * Reason is replaced by an object where its class implement a Http\Client\Exception.
+ *
  * @author Joel Wurtz <joel.wurtz@gmail.com>
  */
 interface Promise

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -18,5 +18,5 @@ interface Promise
      *
      * @return Promise Always returns a new promise which is resolved with value of the executed callback (onFulfilled / onRejected)
      */
-    public function then(callable $onFulfilled = null, callable $onRejected = null);
+    public function then(callable $onFulfilled, callable $onRejected);
 }

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -10,13 +10,31 @@ namespace Http\Client;
  */
 interface Promise
 {
+    const PENDING   = 0;
+    const FULFILLED = 1;
+    const REJECTED  = 2;
+
     /**
      * Add behavior for when the promise is resolved or rejected (response will be available, or error happens)
      *
-     * @param callable $onFulfilled Called when a response will be available, it will receive a Psr\Http\Message\RequestInterface object as the first argument
-     * @param callable $onRejected  Called when an error happens, it will receive a Http\Client\Exception object as the first argument
+     * @param callable $onFulfilled Called when a response will be available.
+     *
+     * It will receive a Psr\Http\Message\RequestInterface object as the first argument
+     * If the callback is null it should not be called.
+     *
+     * @param callable $onRejected  Called when an error happens.
+     *
+     * It will receive a Http\Client\Exception object as the first argument.
+     * If the callback is null it should not be called.
      *
      * @return Promise Always returns a new promise which is resolved with value of the executed callback (onFulfilled / onRejected)
      */
-    public function then(callable $onFulfilled, callable $onRejected);
+    public function then(callable $onFulfilled = null, callable $onRejected = null);
+
+    /**
+     * Get the state of the promise, one of PENDING, FULFILLED or REJECTED
+     *
+     * @return int
+     */
+    public function getState();
 }

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -38,7 +38,7 @@ interface Promise
      * The callback will be called when the response or exception arrived and never more than once.
      *
      * @param callable $onFulfilled Called when a response will be available.
-     * @param callable $onRejected Called when an error happens.
+     * @param callable $onRejected  Called when an error happens.
      *
      * You must always return the Response in the interface or throw an Exception.
      *
@@ -56,27 +56,28 @@ interface Promise
     /**
      * Return the value of the promise (fulfilled).
      *
-     * @throws \LogicException When the promise is not fulfilled.
-     *
      * @return ResponseInterface Response Object only when the Promise is fulfilled.
+     *
+     * @throws \LogicException When the promise is not fulfilled.
      */
     public function getResponse();
 
     /**
      * Return the reason of the promise (rejected).
      *
-     * @throws \LogicException When the promise is not rejected.
-     *
      * @return Exception Exception Object only when the Promise is rejected.
+     *
+     * If the exception is an instance of Http\Client\Exception\HttpException it will contain
+     * the response object with the status code and the http reason.
+     *
+     * @throws \LogicException When the promise is not rejected.
      */
-    public function getError();
+    public function getException();
 
     /**
      * Wait for the promise to be fulfilled or rejected.
      *
-     * This function does not return a result, it simply wait for response or error
-     * of the request to be available, change the state of the promise and call one
-     * of the then callable.
+     * When this method returns, the request has been resolved and the appropriate callable has terminated.
      */
     public function wait();
 }

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Http\Client;
+
+/**
+ * Promise represents a response that may not be available yet, but will be resolved at some point in future.
+ * It acts like a proxy to the actual response.
+ *
+ * @author Joel Wurtz <joel.wurtz@gmail.com>
+ */
+interface Promise
+{
+    /**
+     * Add behavior for when the promise is resolved or rejected (response will be available, or error happens)
+     *
+     * @param callable $onFulfilled Called when a response will be available, it will receive a Psr\Http\Message\RequestInterface object as the first argument
+     * @param callable $onRejected  Called when an error happens, it will receive a Http\Client\Exception object as the first argument
+     *
+     * @return Promise Always returns a new promise which is resolved with value of the executed callback (onFulfilled / onRejected)
+     */
+    public function then(callable $onFulfilled = null, callable $onRejected = null);
+}

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -2,6 +2,8 @@
 
 namespace Http\Client;
 
+use Psr\Http\Message\ResponseInterface;
+
 /**
  * Promise represents a response that may not be available yet, but will be resolved at some point in future.
  * It acts like a proxy to the actual response.
@@ -10,8 +12,27 @@ namespace Http\Client;
  */
 interface Promise
 {
+    /**
+     * Pending state, promise has not been fulfilled or rejected.
+     *
+     * When pending, a promise may transition to either the fulfilled or rejected state.
+     */
     const PENDING   = 0;
+
+    /**
+     * Fulfilled state, promise has been fulfilled with a ResponseInterface object.
+     *
+     * When fulfilled, a promise must not transition to any other state.
+     * When fulfilled, a promise must have a value, which must not change.
+     */
     const FULFILLED = 1;
+
+    /**
+     * Rejected state, promise has been rejected with an Exception object.
+     *
+     * When rejected, a promise must not transition to any other state.
+     * When rejected, a promise must have a reason, which must not change.
+     */
     const REJECTED  = 2;
 
     /**
@@ -21,11 +42,17 @@ interface Promise
      *
      * It will receive a Psr\Http\Message\RequestInterface object as the first argument
      * If the callback is null it must not be called.
+     * It must be called after promise is fulfilled, with promise’s value (ResponseInterface) as its first argument.
+     * It must not be called before promise is fulfilled.
+     * It must not be called more than once.
      *
-     * @param callable $onRejected  Called when an error happens.
+     * @param callable $onRejected Called when an error happens.
      *
      * It will receive a Http\Client\Exception object as the first argument.
      * If the callback is null it must not be called.
+     * It must be called after promise is rejected, with promise’s reason (Exception) as its first argument.
+     * It must not be called before promise is rejected.
+     * It must not be called more than once.
      *
      * @return Promise Always returns a new promise which is resolved with value of the executed callback (onFulfilled / onRejected)
      */
@@ -37,4 +64,18 @@ interface Promise
      * @return int
      */
     public function getState();
+
+    /**
+     * Return the value of the promise (fulfilled)
+     *
+     * @return null|ResponseInterface Null if the promise is rejected or pending, the response object otherwise
+     */
+    public function getResponse();
+
+    /**
+     * Return the reason of the promise (rejected)
+     *
+     * @return null|Exception Null if the promise is fulfilled or pending, the exception object otherwise
+     */
+    public function getError();
 }

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -18,47 +18,29 @@ interface Promise
 {
     /**
      * Pending state, promise has not been fulfilled or rejected.
-     *
-     * When pending, a promise may transition to either the fulfilled or rejected state.
      */
     const PENDING   = 0;
 
     /**
      * Fulfilled state, promise has been fulfilled with a ResponseInterface object.
-     *
-     * When fulfilled, a promise must not transition to any other state.
-     * When fulfilled, a promise must have a value, which must not change.
      */
     const FULFILLED = 1;
 
     /**
      * Rejected state, promise has been rejected with an Exception object.
-     *
-     * When rejected, a promise must not transition to any other state.
-     * When rejected, a promise must have a reason, which must not change.
      */
     const REJECTED  = 2;
 
     /**
-     * Add behavior for when the promise is resolved or rejected (response will be available, or error happens)
+     * Add behavior for when the promise is resolved or rejected (response will be available, or error happens).
      *
      * @param callable $onFulfilled Called when a response will be available.
-     *
-     * It will receive a Psr\Http\Message\ResponseInterface object as the first argument
-     * If the callback is null it must not be called.
-     * It must be called after promise is fulfilled, with promise’s value (ResponseInterface) as its first argument.
-     * It must not be called before promise is fulfilled.
-     * It must not be called more than once.
-     *
      * @param callable $onRejected Called when an error happens.
      *
-     * It will receive a Http\Client\Exception object as the first argument.
-     * If the callback is null it must not be called.
-     * It must be called after promise is rejected, with promise’s reason (Exception) as its first argument.
-     * It must not be called before promise is rejected.
-     * It must not be called more than once.
+     * If you do not care about one of the cases, you can set the corresponding callable to null
+     * The callback will be called when the response or exception arrived and never more than once.
      *
-     * @return Promise Always returns a new promise which is resolved with value of the executed callback (onFulfilled / onRejected)
+     * @return Promise Always returns a new promise which is resolved with value of the executed callback (onFulfilled / onRejected).
      */
     public function then(callable $onFulfilled = null, callable $onRejected = null);
 
@@ -70,16 +52,20 @@ interface Promise
     public function getState();
 
     /**
-     * Return the value of the promise (fulfilled)
+     * Return the value of the promise (fulfilled).
      *
-     * @return null|ResponseInterface Null if the promise is rejected or pending, the response object otherwise
+     * @throws \LogicException When the promise is not fulfilled.
+     *
+     * @return ResponseInterface Response Object only when the Promise is fulfilled.
      */
     public function getResponse();
 
     /**
-     * Return the reason of the promise (rejected)
+     * Return the reason of the promise (rejected).
      *
-     * @return null|Exception Null if the promise is fulfilled or pending, the exception object otherwise
+     * @throws \LogicException When the promise is not rejected.
+     *
+     * @return Exception Exception Object only when the Promise is rejected.
      */
     public function getError();
 }

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -19,26 +19,28 @@ interface Promise
     /**
      * Pending state, promise has not been fulfilled or rejected.
      */
-    const PENDING   = 0;
+    const PENDING   = "pending";
 
     /**
      * Fulfilled state, promise has been fulfilled with a ResponseInterface object.
      */
-    const FULFILLED = 1;
+    const FULFILLED = "fulfilled";
 
     /**
      * Rejected state, promise has been rejected with an Exception object.
      */
-    const REJECTED  = 2;
+    const REJECTED  = "rejected";
 
     /**
      * Add behavior for when the promise is resolved or rejected (response will be available, or error happens).
      *
+     * If you do not care about one of the cases, you can set the corresponding callable to null
+     * The callback will be called when the response or exception arrived and never more than once.
+     *
      * @param callable $onFulfilled Called when a response will be available.
      * @param callable $onRejected Called when an error happens.
      *
-     * If you do not care about one of the cases, you can set the corresponding callable to null
-     * The callback will be called when the response or exception arrived and never more than once.
+     * You must always return the Response in the interface or throw an Exception.
      *
      * @return Promise Always returns a new promise which is resolved with value of the executed callback (onFulfilled / onRejected).
      */
@@ -68,4 +70,13 @@ interface Promise
      * @return Exception Exception Object only when the Promise is rejected.
      */
     public function getError();
+
+    /**
+     * Wait for the promise to be fulfilled or rejected.
+     *
+     * This function does not return a result, it simply wait for response or error
+     * of the request to be available, change the state of the promise and call one
+     * of the then callable.
+     */
+    public function wait();
 }

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -20,12 +20,12 @@ interface Promise
      * @param callable $onFulfilled Called when a response will be available.
      *
      * It will receive a Psr\Http\Message\RequestInterface object as the first argument
-     * If the callback is null it should not be called.
+     * If the callback is null it must not be called.
      *
      * @param callable $onRejected  Called when an error happens.
      *
      * It will receive a Http\Client\Exception object as the first argument.
-     * If the callback is null it should not be called.
+     * If the callback is null it must not be called.
      *
      * @return Promise Always returns a new promise which is resolved with value of the executed callback (onFulfilled / onRejected)
      */


### PR DESCRIPTION
See #74 and #75 discussion for a more detailed description.

This PR intend to add asynchronous support for httplug by adding a new interface `HttpAsyncClient` which allow to send an asynchronous request and return a promise for the response.

The current Promise interface follow specification of https://promisesaplus.com/ from an user point of view (there is no method for fulfilling or rejecting the promise, it should be up to the implementation user only care on how to handle the return and not on how to resolve the promise)
