### PR TITLE
Removed dependency for php-http/promise

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "psr/http-message": "^1.0",
-        "php-http/promise": "^0.1"
+        "psr/http-message": "^1.0"
     },
     "require-dev": {
         "phpspec/phpspec": "^2.4",

--- a/src/HttpAsyncClient.php
+++ b/src/HttpAsyncClient.php
@@ -2,11 +2,10 @@
 
 namespace Http\Client;
 
-use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
 
 /**
- * Sends a PSR-7 Request in an asynchronous way by returning a Promise.
+ * Sends a PSR-7 Request in an asynchronous way by returning a \Http\Promise\Promise.
  *
  * @author Joel Wurtz <joel.wurtz@gmail.com>
  */
@@ -19,7 +18,7 @@ interface HttpAsyncClient
      *
      * @param RequestInterface $request
      *
-     * @return Promise
+     * @return \Http\Promise\Promise
      *
      * @throws \Exception If processing the request is impossible (eg. bad configuration).
      */


### PR DESCRIPTION
There is no technical dependency on `php-http/promise`. Since we only use it in docs I think we should remove it. 

Packages that need the `php-http/promise` should require it directly. See https://github.com/php-http/guzzle6-adapter/pull/26
