### PR TITLE
Remove Typehinting

### DIFF
--- a/src/Promise/HttpFulfilledPromise.php
+++ b/src/Promise/HttpFulfilledPromise.php
@@ -4,19 +4,18 @@ namespace Http\Client\Promise;
 
 use Http\Client\Exception;
 use Http\Promise\Promise;
-use Psr\Http\Message\ResponseInterface;
 
 final class HttpFulfilledPromise implements Promise
 {
     /**
-     * @var ResponseInterface
+     * @var mixed
      */
     private $response;
 
     /**
-     * @param ResponseInterface $response
+     * @param $response
      */
-    public function __construct(ResponseInterface $response)
+    public function __construct($response)
     {
         $this->response = $response;
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT



As done on [php-http/promise](https://github.com/php-http/promise/commit/e342b2d05a0ab368cae8bdfc45678ac73e81b420) I removed the reponse typehinting.

I get the error when trying to make a retry middleware :

> Uncaught TypeError: Argument 1 passed to Http\Client\Promise\HttpFulfilledPromise::__construct() must implement interface Psr\Http\Message\ResponseInterface, instance of Http\Client\Promise\HttpFulfilledPromise given

And I just saw that guzzle implementation does not have too.