### PR TITLE
Change HttpFullFiledPromise constructor parameter to mixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.1.1 - 2017-02-26
+
+### Changed
+
+- HttpFullfilledPromise to allow mixed parameter in constructor
+
 
 ## 1.1.0 - 2016-08-31
 

--- a/src/Promise/HttpFulfilledPromise.php
+++ b/src/Promise/HttpFulfilledPromise.php
@@ -9,14 +9,14 @@ use Psr\Http\Message\ResponseInterface;
 final class HttpFulfilledPromise implements Promise
 {
     /**
-     * @var ResponseInterface
+     * @var mixed
      */
     private $response;
 
     /**
-     * @param ResponseInterface $response
+     * @param mixed $response
      */
-    public function __construct(ResponseInterface $response)
+    public function __construct($response)
     {
         $this->response = $response;
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #123 
| License         | MIT


#### What's in this PR?

Changes the `HttpFulfilledPromise` constructor parameter to mixed instead of `ResponseInterface`


#### Example Usage

```php
return $response->then(
    function (ResponseInterface $response) use ($request) {
        if (200 <= $response->getStatusCode() && $response->getStatusCode() < 300) {
            return 'success';
        } 

        return 'fail';
    }
);
```


#### Checklist

- [X] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix

