### PR TITLE
2.x branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-2.x": "2.0-dev"
+            "dev-2.x": "2.0.x-dev"
         }
     }
 }


### PR DESCRIPTION
Better alias per https://getcomposer.org/doc/articles/aliases.md

We now allow people to `composer req php-http/httplug:2.0.*`