### PR TITLE
Update Http\Client\Exception to extend \Throwable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "require": {
         "php": ">=5.4",
         "psr/http-message": "^1.0",
-        "php-http/promise": "^1.0"
+        "php-http/promise": "^1.0",
+        "dstuecken/php7ify": "^1.1"
     },
     "require-dev": {
         "phpspec/phpspec": "^2.4",

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -7,6 +7,6 @@ namespace Http\Client;
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
  */
-interface Exception
+interface Exception extends \Throwable
 {
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #142 
| License         | MIT


#### What's in this PR?

Updates `Http\Client\Exception` to extend from `\Throwable`. Also includes dstuecken/php7ify to provide a `\Throwable` polyfill for versions of PHP earlier than 7.0.


#### Why?

Static analysis tools are complaining when creating HTTP clients that implement `Http\Client\HttpClient`


#### Example Usage

n/a


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix

*Will update the CHANGELOG if this approach is acceptable to the maintainers.*


#### To Do

n/a
