### PR TITLE
Update minimum PHP version to ^7.0 and modify Http\Client\Exception to extend \Throwable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
-    - 5.4
-    - 5.5
-    - 5.6
     - 7.0
     - 7.1
     - 7.2
@@ -25,13 +22,11 @@ branches:
 matrix:
     fast_finish: true
     include:
-        - php: 5.4
+        - php: 7.0
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-ci"
-        - php: hhvm
-          dist: trusty
 
 before_install:
-    - if [[ $COVERAGE != true && $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini || true; fi
+    - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi
     - travis_retry composer self-update
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": "^7.0",
         "psr/http-message": "^1.0",
         "php-http/promise": "^1.0"
     },

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -7,6 +7,6 @@ namespace Http\Client;
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
  */
-interface Exception
+interface Exception extends \Throwable
 {
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #142 
| License         | MIT


#### What's in this PR?

Updates `Http\Client\Exception` to extend from `\Throwable`. Also updates the library to support only PHP version 7.0.0 and greater, to allow use of the `\Throwable` interface, introduced in PHP 7.


#### Why?

Static analysis tools are complaining when creating HTTP clients that implement `Http\Client\HttpClient`


#### Example Usage

n/a


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix

*Will update the CHANGELOG if this approach is acceptable to the maintainers.*


#### To Do

n/a
