### PR TITLE
stop building with hhvm because it stopped working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ matrix:
     include:
         - php: 5.4
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-ci"
-        - php: hhvm
-          dist: trusty
 
 before_install:
     - if [[ $COVERAGE != true && $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini || true; fi


### PR DESCRIPTION
it seems a recent version of hhvm did a BC break, builds that have been successful now fail with
```
Fatal error: Uncaught TypeError: Argument 1 passed to spec\Http\Client\Exception\HttpExceptionSpec::let() 
must implement interface Psr\Http\Message\RequestInterface, PhpSpec\Wrapper\Collaborator given
 in /home/travis/build/php-http/httplug/spec/Exception/HttpExceptionSpec.php:14
```

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

Drop HHVM support

#### Why?

HHVM build stopped working, and HHVM seems not relevant enough anymore to figure out why.

#### Checklist

no changelog entry and no doc change needed.
