### PR TITLE
Use static instead of self for instancing HttpException

### DIFF
--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -63,6 +63,6 @@ class HttpException extends RequestException
             $response->getReasonPhrase()
         );
 
-        return new self($message, $request, $response, $previous);
+        return new static($message, $request, $response, $previous);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #152
| Documentation   | n/a
| License         | MIT


#### What's in this PR?

Use `new static()` instead of `new self()` for instancing `Http\Client\Exception\HttpException` to really instanciate the final class which called the `create()` method and not just the parent class.

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
