### PR TITLE
PSR-18: Network / Request exception inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `Http\Client\Exception\NetworkException` no longer extends `Http\Client\Exception\RequestException`,
+  in accordance with [PSR-18](https://www.php-fig.org/psr/psr-18/)
 
 ## [2.0.0] - 2018-10-31
 

--- a/spec/Exception/NetworkExceptionSpec.php
+++ b/spec/Exception/NetworkExceptionSpec.php
@@ -17,8 +17,28 @@ class NetworkExceptionSpec extends ObjectBehavior
         $this->shouldHaveType('Http\Client\Exception\NetworkException');
     }
 
-    function it_is_a_request_exception()
+    function it_is_a_transfer_exception()
     {
-        $this->shouldHaveType('Http\Client\Exception\RequestException');
+        $this->shouldHaveType('Http\Client\Exception\TransferException');
+    }
+
+    function it_implements_psr_network_exception_interface()
+    {
+        $this->shouldHaveType('Psr\Http\Client\NetworkExceptionInterface');
+    }
+
+    function it_does_not_implement_psr_request_exception_interface()
+    {
+        $this->shouldNotHaveType('Psr\Http\Client\RequestExceptionInterface');
+    }
+
+    function it_is_not_a_request_exception()
+    {
+        $this->shouldNotHaveType('Http\Client\Exception\RequestException');
+    }
+
+    function it_has_a_request(RequestInterface $request)
+    {
+        $this->getRequest()->shouldReturn($request);
     }
 }

--- a/spec/Exception/RequestExceptionSpec.php
+++ b/spec/Exception/RequestExceptionSpec.php
@@ -2,7 +2,6 @@
 
 namespace spec\Http\Client\Exception;
 
-use Http\Client\Exception\RequestException;
 use Psr\Http\Message\RequestInterface;
 use PhpSpec\ObjectBehavior;
 
@@ -21,6 +20,21 @@ class RequestExceptionSpec extends ObjectBehavior
     function it_is_a_transfer_exception()
     {
         $this->shouldHaveType('Http\Client\Exception\TransferException');
+    }
+
+    function it_implements_psr_request_exception_interface()
+    {
+        $this->shouldHaveType('Psr\Http\Client\RequestExceptionInterface');
+    }
+
+    function it_does_not_implement_psr_network_exception_interface()
+    {
+        $this->shouldNotHaveType('Psr\Http\Client\NetworkExceptionInterface');
+    }
+
+    function it_is_not_a_network_exception()
+    {
+        $this->shouldNotHaveType('Http\Client\Exception\NetworkException');
     }
 
     function it_has_a_request(RequestInterface $request)

--- a/src/Exception/NetworkException.php
+++ b/src/Exception/NetworkException.php
@@ -2,6 +2,7 @@
 
 namespace Http\Client\Exception;
 
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Client\NetworkExceptionInterface as PsrNetworkException;
 
 /**
@@ -11,6 +12,19 @@ use Psr\Http\Client\NetworkExceptionInterface as PsrNetworkException;
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
  */
-class NetworkException extends RequestException implements PsrNetworkException
+class NetworkException extends TransferException implements PsrNetworkException
 {
+    use RequestAwareTrait;
+
+    /**
+     * @param string           $message
+     * @param RequestInterface $request
+     * @param \Exception|null  $previous
+     */
+    public function __construct($message, RequestInterface $request, \Exception $previous = null)
+    {
+        $this->setRequest($request);
+
+        parent::__construct($message, 0, $previous);
+    }
 }

--- a/src/Exception/RequestAwareTrait.php
+++ b/src/Exception/RequestAwareTrait.php
@@ -7,7 +7,7 @@ use Psr\Http\Message\RequestInterface;
 trait RequestAwareTrait
 {
     /**
-     * @var \Psr\Http\Message\RequestInterface
+     * @var RequestInterface
      */
     private $request;
 

--- a/src/Exception/RequestAwareTrait.php
+++ b/src/Exception/RequestAwareTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Http\Client\Exception;
+
+use Psr\Http\Message\RequestInterface;
+
+trait RequestAwareTrait
+{
+    /**
+     * @var \Psr\Http\Message\RequestInterface
+     */
+    private $request;
+
+    /**
+     * @param \Psr\Http\Message\RequestInterface $request
+     */
+    private function setRequest(RequestInterface $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequest(): RequestInterface
+    {
+        return $this->request;
+    }
+}

--- a/src/Exception/RequestAwareTrait.php
+++ b/src/Exception/RequestAwareTrait.php
@@ -11,9 +11,6 @@ trait RequestAwareTrait
      */
     private $request;
 
-    /**
-     * @param \Psr\Http\Message\RequestInterface $request
-     */
     private function setRequest(RequestInterface $request)
     {
         $this->request = $request;

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -15,10 +15,7 @@ use Psr\Http\Client\RequestExceptionInterface as PsrRequestException;
  */
 class RequestException extends TransferException implements PsrRequestException
 {
-    /**
-     * @var RequestInterface
-     */
-    private $request;
+    use RequestAwareTrait;
 
     /**
      * @param string           $message
@@ -27,13 +24,8 @@ class RequestException extends TransferException implements PsrRequestException
      */
     public function __construct($message, RequestInterface $request, \Exception $previous = null)
     {
-        $this->request = $request;
+        $this->setRequest($request);
 
         parent::__construct($message, 0, $previous);
-    }
-
-    public function getRequest(): RequestInterface
-    {
-        return $this->request;
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?   | no
| BC breaks?      | changed exception interface implementation
| Deprecations?   | no
| Related tickets | fixes #155 

#### What's in this PR?

- `Http\Client\Exception\NetworkException` no longer extends `Http\Client\Exception\RequestException`
- `Http\Client\Exception\NetworkException` now extends `Http\Client\Exception\TransferException`
- `Http\Client\Exception\NetworkException` and `Http\Client\Exception\RequestException` both use `Http\Client\Exception\RequestAwareTrait` (not sure if this is the best approach?)

#### Example Usage

``` php
try {
    throw new \Http\Client\Exception\NetworkException(
        'some network problem',
        $someRequest
    );
} catch (\Psr\Http\Client\RequestExceptionInterface $e) {
    echo 'caught request exception';
} catch (\Psr\Http\Client\NetworkExceptionInterface $e) {
    echo 'caught network exception';
}
```

#### Checklist

- [X] Updated CHANGELOG.md to describe bugfix
