### PR TITLE
Allow returning a Promise in onRejected then()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Enabled `HttpRejectedPromise` to return a promise for implementing a retry
+- Enabled the `$onRejected` callback of `HttpRejectedPromise` to return a promise for implementing a retry
   mechanism [#168](https://github.com/php-http/httplug/pull/168)
 
 ## [2.2.0] - 2020-07-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.3.0] - 2022-02-x
+
+### Changed
+
+- Enabled `HttpRejectedPromise` to return a promise for implementing a retry
+  mechanism [#168](https://github.com/php-http/httplug/pull/168)
+
 ## [2.2.0] - 2020-07-13
 
 ### Changed

--- a/spec/Promise/HttpRejectedPromiseSpec.php
+++ b/spec/Promise/HttpRejectedPromiseSpec.php
@@ -4,6 +4,7 @@ namespace spec\Http\Client\Promise;
 
 use Http\Client\Exception;
 use Http\Client\Exception\TransferException;
+use Http\Client\Promise\HttpFulfilledPromise;
 use Http\Promise\Promise;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -86,5 +87,20 @@ class HttpRejectedPromiseSpec extends ObjectBehavior
         $this->shouldThrow('Exception')->duringThen(null, function () {
             throw new \Exception();
         });
+    }
+
+    function it_returns_a_promise_when_rejected(ResponseInterface $response)
+    {
+        $exception = new TransferException();
+        $this->beConstructedWith($exception);
+
+        $promise = $this->then(null, function (Exception $exceptionReceived) use($exception, $response) {
+            return new HttpFulfilledPromise($response->getWrappedObject());
+        });
+
+        $promise->shouldHaveType('Http\Promise\Promise');
+        $promise->shouldHaveType('Http\Client\Promise\HttpFulfilledPromise');
+        $promise->getState()->shouldReturn(Promise::FULFILLED);
+        $promise->wait()->shouldReturnAnInstanceOf('Psr\Http\Message\ResponseInterface');
     }
 }

--- a/src/Promise/HttpRejectedPromise.php
+++ b/src/Promise/HttpRejectedPromise.php
@@ -4,7 +4,6 @@ namespace Http\Client\Promise;
 
 use Http\Client\Exception;
 use Http\Promise\Promise;
-use Psr\Http\Message\ResponseInterface;
 
 final class HttpRejectedPromise implements Promise
 {

--- a/src/Promise/HttpRejectedPromise.php
+++ b/src/Promise/HttpRejectedPromise.php
@@ -4,6 +4,7 @@ namespace Http\Client\Promise;
 
 use Http\Client\Exception;
 use Http\Promise\Promise;
+use Psr\Http\Message\ResponseInterface;
 
 final class HttpRejectedPromise implements Promise
 {
@@ -27,7 +28,11 @@ final class HttpRejectedPromise implements Promise
         }
 
         try {
-            return new HttpFulfilledPromise($onRejected($this->exception));
+            $result = $onRejected($this->exception);
+            if ($result instanceof Promise) {
+                return $result;
+            }
+            return new HttpFulfilledPromise($result);
         } catch (Exception $e) {
             return new self($e);
         }

--- a/src/Promise/HttpRejectedPromise.php
+++ b/src/Promise/HttpRejectedPromise.php
@@ -31,6 +31,7 @@ final class HttpRejectedPromise implements Promise
             if ($result instanceof Promise) {
                 return $result;
             }
+
             return new HttpFulfilledPromise($result);
         } catch (Exception $e) {
             return new self($e);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


#### What's in this PR?

This PR allows to return a Promise in the `onRejected` callable function for `HttpRejectedPromise`. Right now is only possible to return a `ResponseInterface` for the `$onRejected($this->exception)` call, see [here](https://github.com/php-http/httplug/blob/master/src/Promise/HttpRejectedPromise.php#L30).


#### Why?

I'm proposing this change because I'm trying to implement a retry mechanism for async requests (related to this issue https://github.com/php-http/client-common/issues/112). I did a POC in [elastic-transport-php](https://github.com/elastic/elastic-transport-php) library that is using HTTPlug. See [8.x branch](https://github.com/elastic/elastic-transport-php/blob/8.x/src/Transport.php#L336-L384) for the details.


#### Example Usage

Using this change we can easily implements a retry mechanism as follows:

``` php
use Http\Discovery\HttpAsyncClientDiscovery;
use Http\Discovery\Psr17FactoryDiscovery;

$client = HttpAsyncClientDiscovery::find();
$requestFactory = Psr17FactoryDiscovery::findRequestFactory();
$retries = 2; // number of HTTP retries
$request = $requestFactory->createRequest("GET", "http://localhost:8080/test");

// onFulfilled callable
$onFulfilled = function (ResponseInterface $response) {
    return $response;
};
// onRejected callable
$onRejected = function (Exception $e) use ($client, $request) {
    // $request can be different, e.g. using a Round-Robin algorithm

    // try another execution
    return $client->sendAsyncRequest($request);
};
$promise = $client->sendAsyncRequest($request);
for ($i=0; $i < $retries; $i++) {
    $promise = $promise->then($onFulfilled, $onRejected);
}
// Add the last callable to manage the exceeded maximum number of retries
$promise->then($onFulfilled, function(\Exception $e) {
    throw new \Exception(sprintf(
        "Exceeded maximum number of retries (%d): %s",
        $retries,
        $e->getMessage()
    ));
});
```

#### To Do

- [ ] I'm not sure if a documentation pull request is needed
