### PR TITLE
Make nullable parameter types explicit

### DIFF
--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -26,7 +26,7 @@ class HttpException extends RequestException
         $message,
         RequestInterface $request,
         ResponseInterface $response,
-        \Exception $previous = null
+        ?\Exception $previous = null
     ) {
         parent::__construct($message, $request, $previous);
 
@@ -50,7 +50,7 @@ class HttpException extends RequestException
     public static function create(
         RequestInterface $request,
         ResponseInterface $response,
-        \Exception $previous = null
+        ?\Exception $previous = null
     ) {
         $message = sprintf(
             '[url] %s [http method] %s [status code] %s [reason phrase] %s',

--- a/src/Exception/NetworkException.php
+++ b/src/Exception/NetworkException.php
@@ -19,7 +19,7 @@ class NetworkException extends TransferException implements PsrNetworkException
     /**
      * @param string $message
      */
-    public function __construct($message, RequestInterface $request, \Exception $previous = null)
+    public function __construct($message, RequestInterface $request, ?\Exception $previous = null)
     {
         $this->setRequest($request);
 

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -20,7 +20,7 @@ class RequestException extends TransferException implements PsrRequestException
     /**
      * @param string $message
      */
-    public function __construct($message, RequestInterface $request, \Exception $previous = null)
+    public function __construct($message, RequestInterface $request, ?\Exception $previous = null)
     {
         $this->setRequest($request);
 

--- a/src/Promise/HttpFulfilledPromise.php
+++ b/src/Promise/HttpFulfilledPromise.php
@@ -18,7 +18,7 @@ final class HttpFulfilledPromise implements Promise
         $this->response = $response;
     }
 
-    public function then(callable $onFulfilled = null, callable $onRejected = null)
+    public function then(?callable $onFulfilled = null, ?callable $onRejected = null)
     {
         if (null === $onFulfilled) {
             return $this;

--- a/src/Promise/HttpRejectedPromise.php
+++ b/src/Promise/HttpRejectedPromise.php
@@ -17,7 +17,7 @@ final class HttpRejectedPromise implements Promise
         $this->exception = $exception;
     }
 
-    public function then(callable $onFulfilled = null, callable $onRejected = null)
+    public function then(?callable $onFulfilled = null, ?callable $onRejected = null)
     {
         if (null === $onRejected) {
             return $this;


### PR DESCRIPTION
#### What's in this PR?

This PR turns implicit nullable parameter types to explicit ones.


#### Why?

PHP allows to implicitly declare a nullable parameter type by setting the parameter's default value to `null`. However, in PHP 8.4 this syntax has been deprecated.

https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

see also php-http/promise#34